### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,3 @@
 [install]
-home=.
 force=1
 


### PR DESCRIPTION
This gives a problem when setup.py is called with a `--prefix` flag, for example:

```
$ python2 -s setup.py --no-user-cfg install --prefix=/home/gijs/Work/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.3.0/sigpyproc-2018-04-08-xsymjlcmozkspufwfobq2ubsp7i46z3q

 error: must supply either home or prefix/exec-prefix -- not both
```